### PR TITLE
remove default comparator argument to null

### DIFF
--- a/src/lib/sortobject.coffee
+++ b/src/lib/sortobject.coffee
@@ -1,5 +1,5 @@
 # Define
-sortObject = (obj,comparator=null) ->
+sortObject = (obj,comparator) ->
 	# Arrays
 	if Array.isArray(obj)
 		result = []


### PR DESCRIPTION
this fixes compatibility on firefox, otherwise we get
`invalid Array.prototype.sort argument`