### PR TITLE
Add strict header to support nodejs v4 (#1)

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = function sortObject (obj, comparator) {
 	// Arrays
 	if ( Array.isArray(obj) ) {


### PR DESCRIPTION
Fixes:
```
      webpack:///<path>/~/sortobject/source/index.js:5
		for ( let i = 0; i < obj.length; ++i ) {
		      ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at Object.exports.runInThisContext (vm.js:53:16)
    at Object.<anonymous> ([stdin]-wrapper:6:22)
    at Module._compile (module.js:409:26)
    at node.js:579:27
    at nextTickCallbackWith0Args (node.js:420:9)
    at process._tickCallback (node.js:349:13)
```